### PR TITLE
Fix score and lives updates

### DIFF
--- a/js/enemy.js
+++ b/js/enemy.js
@@ -122,7 +122,7 @@ class EnemyTank {
     takeDamage() {
         if (!this.isDestroyed) {
             this.destroy();
-            state.score += this.score;
+            state.setScore(state.score + this.score);
             state.setTanksDestroyed(state.tanksDestroyed + 1);
             state.setEnemiesRemaining(state.enemiesRemaining - 1);
         }

--- a/js/main.js
+++ b/js/main.js
@@ -302,7 +302,7 @@ function checkWaveCompletion() {
         
         // Calculate wave completion bonus
         const waveBonus = completedWave * 50;
-        state.score += waveBonus;
+        state.setScore(state.score + waveBonus);
         
         // Show wave completion message
         if (typeof showWaveCompletionMessage === 'function') {

--- a/js/projectile.js
+++ b/js/projectile.js
@@ -152,7 +152,7 @@ export function updateProjectiles(gameOver) {
             if (checkCollision(projectile, state.tankBody, 1.5)) {
                 if (!state.playerInvulnerable) {
                     playSound('hit');
-                    state.lives--;
+                    state.setLives(state.lives - 1);
                     
                     // Show damage flash effect
                     showDamageFlash();


### PR DESCRIPTION
## Summary
- use `setScore` when awarding enemy and wave points so bonus lives are granted
- use `setLives` to decrement lives on hit

## Testing
- `node code-checker.js | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_688647ebe1548328a1b9c354f67cad8a