### PR TITLE
Add power-up pickups and HUD support

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
             <div>TANK: 1000 pts | MISSILE: 2000 pts</div>
             <div>SUPERTANK: 3000 pts | UFO: 5000 pts</div>
             <div>BONUS LIFE EVERY 15,000 POINTS</div>
+            <div>GRAB GLOWING PICKUPS: SHIELD, RAPID FIRE, OR REPAIRS</div>
           </div>
         </div>
         <button id="startButton">PRESS TO START</button>
@@ -36,6 +37,7 @@
     <div id="score">SCORE 000000</div>
     <div id="hiScore">HI-SCORE 000000</div>
     <div id="waveInfo">WAVE 1  ENEMY 0</div>
+    <div id="powerUps">POWERUPS NONE</div>
     <div id="health">LIVES 3</div>
     <div class="damage-flash"></div>
     <div class="invulnerable-indicator">SHIELD ACTIVE</div>

--- a/js/enemy.js
+++ b/js/enemy.js
@@ -22,6 +22,7 @@ import * as state from './state.js';
 import { createExplosion } from './effects.js';
 import { checkCollision } from './utils.js';
 import { projectilePool } from './projectile.js';
+import { maybeDropPowerUp } from './powerups.js';
 
 /**
  * ENEMY TANK CLASS
@@ -155,6 +156,7 @@ class EnemyTank {
             state.setScore(state.score + this.score);
             state.setTanksDestroyed(state.tanksDestroyed + 1);
             state.setEnemiesRemaining(state.enemiesRemaining - 1);
+            maybeDropPowerUp(this.body.position);
         }
     }
     
@@ -288,6 +290,7 @@ class EnemyMissile {
             state.setScore(state.score + this.score);
             state.setTanksDestroyed(state.tanksDestroyed + 1);
             state.setEnemiesRemaining(state.enemiesRemaining - 1);
+            maybeDropPowerUp(this.body.position);
         }
     }
     
@@ -417,6 +420,7 @@ class EnemySuperTank {
             state.setScore(state.score + this.score);
             state.setTanksDestroyed(state.tanksDestroyed + 1);
             state.setEnemiesRemaining(state.enemiesRemaining - 1);
+            maybeDropPowerUp(this.body.position);
         }
     }
     
@@ -500,6 +504,7 @@ class EnemyUFO {
             state.setScore(state.score + this.score);
             state.setTanksDestroyed(state.tanksDestroyed + 1);
             // UFO doesn't count towards wave completion
+            maybeDropPowerUp(this.body.position);
         }
     }
     

--- a/js/hud.js
+++ b/js/hud.js
@@ -14,6 +14,12 @@
 import * as state from './state.js';
 import { GAME_PARAMS } from './constants.js';
 
+const POWER_UP_LABELS = {
+    shield: 'SHIELD',
+    rapidFire: 'RAPID FIRE',
+    repair: '+1 LIFE',
+};
+
 export function createHUD() {
     // Use existing HTML elements instead of creating new ones
     const radar = document.getElementById('radar');
@@ -119,6 +125,28 @@ export function updateWaveDisplay() {
         const enemies = Math.max(0, state.enemiesRemaining);
         const formattedEnemies = enemies.toString().padStart(2, '0');
         waveDiv.textContent = `WAVE ${state.currentWave}  ENEMY ${formattedEnemies}`;
+    }
+}
+
+export function updatePowerUpDisplay() {
+    const powerUpDiv = document.getElementById('powerUps');
+    if (!powerUpDiv) return;
+
+    const now = Date.now();
+    const activeEntries = Object.entries(state.activePowerUps)
+        .filter(([, expiresAt]) => expiresAt > now)
+        .map(([type, expiresAt]) => {
+            const label = POWER_UP_LABELS[type] || type.toUpperCase();
+            const remaining = Math.max(0, (expiresAt - now) / 1000).toFixed(1);
+            return `${label} ${remaining}s`;
+        });
+
+    if (activeEntries.length === 0) {
+        powerUpDiv.textContent = 'POWERUPS NONE';
+        powerUpDiv.classList.remove('power-ups--active');
+    } else {
+        powerUpDiv.textContent = activeEntries.join('   ');
+        powerUpDiv.classList.add('power-ups--active');
     }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -17,11 +17,12 @@ import { GAME_PARAMS } from './constants.js';
 import * as state from './state.js';
 import { initProjectiles, updateProjectiles, fireProjectile } from './projectile.js';
 import { initEffects, createExplosion, updateCameraShake } from './effects.js';
-import { createHUD, updateLivesDisplay, updateRadar, updateWaveDisplay, showWaveCompletionMessage } from './hud.js';
+import { createHUD, updateLivesDisplay, updateRadar, updateWaveDisplay, showWaveCompletionMessage, updatePowerUpDisplay } from './hud.js';
 import { initSounds, playSound } from './sound.js';
 import { createMountainRange, createHorizontalGrid, createObstacles } from './world.js';
 import { createPlayer, handleMovement, resetTracks } from './player.js';
 import { spawnWave } from './enemy.js';
+import { initPowerUps, rewardWaveClear, updatePowerUps, resetPowerUpTimers } from './powerups.js';
 
 /**
  * Initialize the game scene, renderer, and all game systems
@@ -60,6 +61,8 @@ function init() {
     createObstacles();      // Pyramids and blocks for cover
     createPlayer();         // Create player tank and camera setup
     createHUD();           // Radar, score, lives display (must be after canvas)
+    initPowerUps();        // Reset power-up system before play
+    resetPowerUpTimers();  // Schedule the first drop
 
     // === INITIAL WAVE ===
     spawnWave(state.currentWave);
@@ -78,7 +81,7 @@ function init() {
         if (event.code === 'Space') {
             event.preventDefault();
             const now = Date.now();
-            const fireRate = GAME_PARAMS.FIRE_COOLDOWN;
+            const fireRate = GAME_PARAMS.FIRE_COOLDOWN * state.fireCooldownModifier;
             if (now - lastFireTime > fireRate) {
                 fireProjectile();
                 lastFireTime = now;
@@ -96,7 +99,7 @@ function init() {
 
     const handleMouseClick = () => {
         const now = Date.now();
-        const fireRate = GAME_PARAMS.FIRE_COOLDOWN;
+        const fireRate = GAME_PARAMS.FIRE_COOLDOWN * state.fireCooldownModifier;
         if (now - lastFireTime > fireRate) {
             fireProjectile();
             lastFireTime = now;
@@ -133,15 +136,17 @@ function animate() {
         if (!state.isGameOver) {
             handleMovement();
             updateProjectiles(gameOver);
+            updatePowerUps();
             // Update all active enemies (tanks, missiles, supertanks)
             state.enemyTanks.filter(enemy => !enemy.isDestroyed).forEach(enemy => {
                 if (enemy.update) enemy.update();
             });
             updateRadar();
             updateWaveDisplay();
+            updatePowerUpDisplay();
             checkWaveCompletion();
         }
-        
+
         updateLivesDisplay();
         updateCameraShake(); // Update camera shake effect
         
@@ -294,6 +299,19 @@ function resetGameState() {
     }
     state.projectiles.length = 0;
 
+    // Clear power-ups from the field
+    state.powerUps.forEach(powerUp => state.scene.remove(powerUp));
+    state.clearPowerUps();
+    state.setActivePowerUps({});
+    state.setFireCooldownModifier(1);
+    state.setPlayerProjectileLimit(1);
+    state.setInvulnerableUntil(0);
+    const invulnerabilityIndicator = document.querySelector('.invulnerable-indicator');
+    if (invulnerabilityIndicator) {
+        invulnerabilityIndicator.classList.remove('active');
+    }
+    resetPowerUpTimers();
+
     // Clear all enemies
     for (const enemy of state.enemyTanks) {
         state.scene.remove(enemy.body);
@@ -324,10 +342,13 @@ function checkWaveCompletion() {
         if (typeof showWaveCompletionMessage === 'function') {
             showWaveCompletionMessage(waveBonus);
         }
-        
+
         // Play victory sound
         playSound('waveComplete');
-        
+
+        // Drop a reward to celebrate the clear
+        rewardWaveClear(completedWave);
+
         // Increase difficulty for next wave
         increaseDifficulty();
         

--- a/js/powerups.js
+++ b/js/powerups.js
@@ -1,0 +1,193 @@
+/**
+ * POWER-UP SYSTEM
+ *
+ * Adds collectible battlefield modifiers that reward aggressive play and wave clears.
+ * Power-ups are rare, visually bright pickups that rotate and reward the player with
+ * temporary shields, rapid-fire cannons, or emergency repairs.
+ */
+
+import * as THREE from 'three';
+import { VECTOR_GREEN, VECTOR_YELLOW } from './constants.js';
+import * as state from './state.js';
+import { createExplosion, shakeCamera } from './effects.js';
+import { toggleInvulnerabilityIndicator } from './projectile.js';
+import { playSound } from './sound.js';
+
+const POWER_UP_CONFIG = {
+    shield: {
+        duration: 8000,
+        color: 0x00ff88,
+        label: 'SHIELD',
+    },
+    rapidFire: {
+        duration: 6500,
+        color: VECTOR_YELLOW,
+        label: 'RAPID FIRE',
+    },
+    repair: {
+        duration: 0,
+        color: VECTOR_GREEN,
+        label: '+1 LIFE',
+    },
+};
+
+let nextSpawnTime = Date.now() + 15000;
+
+function createPowerUpMesh(type, position) {
+    const { color } = POWER_UP_CONFIG[type];
+    const geometry = new THREE.OctahedronGeometry(2.2);
+    const wire = new THREE.LineSegments(
+        new THREE.EdgesGeometry(geometry),
+        new THREE.LineBasicMaterial({ color })
+    );
+
+    wire.position.copy(position);
+    wire.position.y = 2.5;
+    wire.userData.type = type;
+    wire.userData.spin = 0.01 + Math.random() * 0.02;
+    return wire;
+}
+
+function getRandomType() {
+    const roll = Math.random();
+    if (roll < 0.45) return 'shield';
+    if (roll < 0.8) return 'rapidFire';
+    return 'repair';
+}
+
+function findSpawnPosition(basePosition) {
+    const radius = 20 + Math.random() * 30;
+    const angle = Math.random() * Math.PI * 2;
+    const offset = new THREE.Vector3(Math.cos(angle) * radius, 0, Math.sin(angle) * radius);
+    const position = basePosition ? basePosition.clone().add(offset) : offset;
+    const clamped = Math.min(Math.max(radius, 10), 60);
+
+    position.x = THREE.MathUtils.clamp(position.x, -clamped, clamped);
+    position.z = THREE.MathUtils.clamp(position.z, -clamped, clamped);
+    return position;
+}
+
+export function initPowerUps() {
+    state.clearPowerUps();
+    state.setActivePowerUps({});
+    state.setFireCooldownModifier(1);
+    state.setPlayerProjectileLimit(1);
+    state.setInvulnerableUntil(0);
+    toggleInvulnerabilityIndicator(false);
+}
+
+export function spawnPowerUp(type = getRandomType(), anchor) {
+    if (!state.scene) return;
+    if (state.powerUps.length >= 3) return;
+
+    const position = findSpawnPosition(anchor || state.tankBody?.position || new THREE.Vector3());
+    const mesh = createPowerUpMesh(type, position);
+    state.scene.add(mesh);
+    state.addPowerUp(mesh);
+}
+
+export function maybeDropPowerUp(position) {
+    if (Math.random() < 0.25) {
+        spawnPowerUp(getRandomType(), position);
+    }
+}
+
+export function rewardWaveClear(waveNumber) {
+    const type = waveNumber % 2 === 0 ? 'rapidFire' : 'shield';
+    spawnPowerUp(type, state.tankBody?.position);
+}
+
+function activatePowerUp(type) {
+    const config = POWER_UP_CONFIG[type];
+    if (!config) return;
+
+    playSound('newWave');
+    shakeCamera(0.6, 240);
+
+    if (type === 'repair') {
+        state.setLives(state.lives + 1);
+        return;
+    }
+
+    const expiresAt = Date.now() + config.duration;
+    state.setActivePowerUp(type, expiresAt);
+
+    if (type === 'shield') {
+        state.setPlayerInvulnerable(true);
+        state.setInvulnerableUntil(Math.max(state.invulnerableUntil, expiresAt));
+        toggleInvulnerabilityIndicator(true);
+    }
+
+    if (type === 'rapidFire') {
+        state.setFireCooldownModifier(0.35);
+        state.setPlayerProjectileLimit(3);
+    }
+}
+
+function deactivatePowerUp(type) {
+    state.clearActivePowerUp(type);
+
+    if (type === 'shield' && Date.now() >= state.invulnerableUntil) {
+        state.setPlayerInvulnerable(false);
+        state.setInvulnerableUntil(0);
+        toggleInvulnerabilityIndicator(false);
+    }
+
+    if (type === 'rapidFire') {
+        state.setFireCooldownModifier(1);
+        state.setPlayerProjectileLimit(1);
+    }
+}
+
+function removePowerUpMesh(powerUp) {
+    state.removePowerUp(powerUp);
+    if (powerUp.parent) {
+        powerUp.parent.remove(powerUp);
+    }
+}
+
+export function updatePowerUps() {
+    const now = Date.now();
+
+    // Timed spawn cadence to keep pickups flowing
+    if (now > nextSpawnTime && !state.isGameOver) {
+        spawnPowerUp();
+        nextSpawnTime = now + 20000 + Math.random() * 5000;
+    }
+
+    // Expire active effects
+    Object.entries(state.activePowerUps).forEach(([type, expiresAt]) => {
+        if (expiresAt <= now) {
+            deactivatePowerUp(type);
+        }
+    });
+
+    for (let i = state.powerUps.length - 1; i >= 0; i--) {
+        const powerUp = state.powerUps[i];
+        if (!powerUp) {
+            state.powerUps.splice(i, 1);
+            continue;
+        }
+
+        if (!state.tankBody) continue;
+
+        powerUp.rotation.y += powerUp.userData.spin;
+        powerUp.rotation.x += 0.01;
+
+        // Pulsing effect
+        const scale = 1 + Math.sin(now * 0.005) * 0.1;
+        powerUp.scale.set(scale, scale, scale);
+
+        // Pickup detection
+        const distance = powerUp.position.distanceTo(state.tankBody.position);
+        if (distance < 3.5) {
+            activatePowerUp(powerUp.userData.type);
+            createExplosion(powerUp.position, powerUp.material.color.getHex(), 2.5);
+            removePowerUpMesh(powerUp);
+        }
+    }
+}
+
+export function resetPowerUpTimers() {
+    nextSpawnTime = Date.now() + 15000;
+}

--- a/js/projectile.js
+++ b/js/projectile.js
@@ -37,7 +37,7 @@ function showDamageFlash() {
  * Show/hide invulnerability indicator after player is hit
  * @param {boolean} show - Whether to show or hide the indicator
  */
-function showInvulnerabilityIndicator(show) {
+export function toggleInvulnerabilityIndicator(show) {
     const indicator = document.querySelector('.invulnerable-indicator');
     if (indicator) {
         if (show) {
@@ -51,6 +51,21 @@ function showInvulnerabilityIndicator(show) {
 // === PROJECTILE SYSTEM ===
 
 export let projectilePool;
+
+function grantInvulnerability(durationMs) {
+    const expiresAt = Date.now() + durationMs;
+    state.setInvulnerableUntil(Math.max(state.invulnerableUntil, expiresAt));
+    state.setPlayerInvulnerable(true);
+    toggleInvulnerabilityIndicator(true);
+
+    setTimeout(() => {
+        if (Date.now() >= state.invulnerableUntil) {
+            state.setPlayerInvulnerable(false);
+            state.setInvulnerableUntil(0);
+            toggleInvulnerabilityIndicator(false);
+        }
+    }, durationMs + 50);
+}
 
 /**
  * Initialize the projectile object pool system
@@ -92,9 +107,10 @@ export function fireProjectile() {
         return;
     }
 
-    // AUTHENTIC BATTLE ZONE: Only one projectile at a time!
-    const hasPlayerProjectile = state.projectiles.some(p => !p.userData.isEnemyProjectile);
-    if (hasPlayerProjectile) {
+    // AUTHENTIC BATTLE ZONE: Only one projectile at a time unless power-ups allow more
+    const activePlayerProjectiles = state.projectiles.filter(p => !p.userData.isEnemyProjectile).length;
+    const playerLimit = state.playerProjectileLimit || 1;
+    if (activePlayerProjectiles >= playerLimit) {
         console.log('❌ Cannot fire - already have player projectile in flight');
         return;
     }
@@ -194,16 +210,11 @@ export function updateProjectiles(gameOver) {
                     playSound('hit');
                     state.setLives(state.lives - 1);
                     showDamageFlash();
-                    
+
                     if (state.lives <= 0) {
                         gameOver();
                     } else {
-                        state.setPlayerInvulnerable(true);
-                        showInvulnerabilityIndicator(true);
-                        setTimeout(() => { 
-                            state.setPlayerInvulnerable(false); 
-                            showInvulnerabilityIndicator(false);
-                        }, 1500);
+                        grantInvulnerability(1500);
                         shakeCamera(2.0, 800);
                         createExplosion(state.tankBody.position, 0xff4444, 4.0);
                     }

--- a/js/state.js
+++ b/js/state.js
@@ -26,6 +26,7 @@ export let tanksDestroyed = 0;
 export let lastBonusLifeScore = 0;
 export let isGameOver = false;
 export let playerInvulnerable = false;
+export let invulnerableUntil = 0;
 export let radarContext;
 export let currentWave = 1;
 export let enemiesRemaining = 0;
@@ -34,6 +35,10 @@ export let handleKeyDown, handleKeyUp;
 // Removed healthLabel - not needed in authentic Battle Zone
 export let gameOverScreen;
 export let highScore = 0;
+export let powerUps = [];
+export let activePowerUps = {};
+export let fireCooldownModifier = 1;
+export let playerProjectileLimit = 1;
 
 
 export function setScene(s) { scene = s; }
@@ -45,6 +50,7 @@ export function setTankCannon(c) { tankCannon = c; }
 // Removed setPlayerHealth - not needed in authentic Battle Zone
 export function setGameOver(g) { isGameOver = g; }
 export function setPlayerInvulnerable(i) { playerInvulnerable = i; }
+export function setInvulnerableUntil(t) { invulnerableUntil = t; }
 export function setRadarContext(c) { radarContext = c; }
 export function setCurrentWave(w) { currentWave = w; }
 export function setEnemiesRemaining(e) { enemiesRemaining = e; }
@@ -67,3 +73,11 @@ export function setLastBonusLifeScore(s) { lastBonusLifeScore = s; }
 export function setHandleKeyDown(h) { handleKeyDown = h; }
 export function setHandleKeyUp(h) { handleKeyUp = h; }
 export function setHighScore(h) { highScore = h; }
+export function addPowerUp(p) { powerUps.push(p); }
+export function removePowerUp(p) { powerUps = powerUps.filter(item => item !== p); }
+export function clearPowerUps() { powerUps = []; }
+export function setActivePowerUps(powers) { activePowerUps = powers; }
+export function setActivePowerUp(name, expiresAt) { activePowerUps[name] = expiresAt; }
+export function clearActivePowerUp(name) { delete activePowerUps[name]; }
+export function setFireCooldownModifier(modifier) { fireCooldownModifier = modifier; }
+export function setPlayerProjectileLimit(limit) { playerProjectileLimit = limit; }

--- a/style.css
+++ b/style.css
@@ -54,6 +54,7 @@ canvas:not(#radar canvas) {
 #score,
 #hiScore,
 #waveInfo,
+#powerUps,
 #health {
     position: fixed;
     color: #00ff00;
@@ -82,6 +83,18 @@ canvas:not(#radar canvas) {
     top: 52px;
     left: 50%;
     transform: translateX(-50%);
+}
+
+#powerUps {
+    top: 82px;
+    left: 28px;
+    font-size: 18px;
+    min-width: 200px;
+}
+
+#powerUps.power-ups--active {
+    color: #ffff00;
+    text-shadow: 0 0 10px rgba(255, 255, 0, 0.8);
 }
 
 #health {


### PR DESCRIPTION
## Summary
- add rotating battlefield power-up pickups that spawn on waves and enemy kills for shields, rapid fire, or repairs
- track power-up timers, rapid-fire firing limits, and invulnerability using shared state and HUD readout
- refresh HUD/start screen styling to highlight pickups and reset indicators cleanly between games

## Testing
- python -m http.server 8000
- Captured screenshot: ![Power-up HUD](browser:/invocations/gysfmezi/artifacts/artifacts/powerups.png)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4506fe288328a389c09fab247db1)